### PR TITLE
Fixing an issue where the official icons also became big.

### DIFF
--- a/_assets/css/index.scss
+++ b/_assets/css/index.scss
@@ -64,7 +64,7 @@ $theme-hero-image: asset_path("DisabilityIN-stock-hero.jpg");
   -webkit-mask: url("../img/usa-icons/expand_less.svg") no-repeat center/contain;
 }
 
-.usa-media-block__img {
+.usa-graphic-list .usa-media-block__img {
   width: 132px;
   height: 132px;
   background-color: #edf5ff;
@@ -75,7 +75,7 @@ $theme-hero-image: asset_path("DisabilityIN-stock-hero.jpg");
   justify-content: center;
 }
 
-.usa-media-block__img img {
+.usa-graphic-list .usa-media-block__img img {
   width: 64px;
   height: 64px;
 }


### PR DESCRIPTION
This change targets the homepage icons list only.

QA

1. Visit https://federalist-6d3494a6-5b03-42fa-82f2-57f3bbb203af.app.cloud.gov/preview/gsa/openacr-website/tweak-front-page-icon-classes/
2. At the top click 'Here's how you know'.
3. Confirm icons are small.
4. Confirm homepage middle icons are the same as before.